### PR TITLE
Fix table in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,8 +209,7 @@ A-hend-all e vez gounezet arc'hant dre chaseal ha pesketa.
 | Mongolian            | Монгол хэл |`khk` | `mn`  |`mn` | ✔          |   ✔     |    ✔   |        ✔     |
 | Maltese              | Malti     |`mlt` | `mt`  |`mt` |      ✔       |      ✔     |      ✔      |         ✔   |
 | Dutch                | Nederlands     |`nld` | `nl` |`nl`  |   ✔         |     ✔      |    ✔      |            |
-| Norwegian Nynorsk | Nynorsk |`nno` | `nn-NO` |`nn`  |            |     ✔      |    ✔      |            |
-
+| Norwegian Nynorsk    | Nynorsk |`nno` | `nn-NO` |`nn`  |            |     ✔      |    ✔      |            |
 | Oriya                | ଓଡ଼ିଆ                                       |`ori` | `or`  |`or` |            |     ✔      |    ✔      |        ✔     |
 | Punjabi              | ਪੰਜਾਬੀ     |`pan` | `pa-IN`   | `pa`  |          |       ✔    |     ✔     |            |
 | Polish               | Polski     |`pol` | `pl`  |`pl` |   ✔          |       ✔     |     ✔     |            |


### PR DESCRIPTION
The last part of the table after "Norwegian Nynorsk" has been malformed.