### PR TITLE
Add missing a to catalan alphabet

### DIFF
--- a/cvutils/data/ca/alphabet.txt
+++ b/cvutils/data/ca/alphabet.txt
@@ -1,1 +1,1 @@
-áàbcçdeéèfghiíïjklmnoóòpqrstuúüvwxyz'·-
+aáàbcçdeéèfghiíïjklmnoóòpqrstuúüvwxyz'·-


### PR DESCRIPTION
A l’alfabet en català li falta la "a" sense accents diacrítics