### PR TITLE
tr - validation: Replace unicode horizontal ellipsis U+2026

### DIFF
--- a/cvutils/data/tr/validate.tsv
+++ b/cvutils/data/tr/validate.tsv
@@ -15,6 +15,7 @@ REPL	?	_	003f	_
 REPL	‘	_	2018	_
 REPL	“	_	201c	_
 REPL	”	_	201d	_
+REPL	…	_	2026	_
 SKIP	0	_	0030	_
 SKIP	1	_	0031	_
 SKIP	2	_	0032	_


### PR DESCRIPTION
https://www.compart.com/en/unicode/U+2026

This character is converted automatically by resources like MS Word. I.e. [ ... => … ]

As this char saves 2 characters, I used it extensively while adding sentences to the Sentence Collector.

I would suggest adding this change in other languages as well...
