### PR TITLE
' is a valid character in Italian

### DIFF
--- a/cvutils/data/it/validate.tsv
+++ b/cvutils/data/it/validate.tsv
@@ -3,7 +3,6 @@ NFKC	_	_	_	_
 REPL	"	_	_	_
 REPL	”	_	_	_
 REPL	“	_	_	_
-REPL	'	_	_	_
 REPL	,	_	_	_
 REPL	-	_	_	_
 REPL	–	_	_	_


### PR DESCRIPTION
Hi!
I think I found an error here for Italian, the ' is a valid character for Italian and in [cvutils/data/it/validate.tsv#L6](https://github.com/ftyers/commonvoice-utils/blob/main/cvutils/data/it/validate.tsv#L6) it is replaced with blank, even if there seem to be other rules below in the same file converting other symbols to ' and later allowing '.
Maybe I'm not seeing a reason to have that replacement rule there on line 6?
Thanks for the useful tools!