### PR TITLE
Fix covo command line in Anaconda

### DIFF
--- a/covo
+++ b/covo
@@ -40,7 +40,7 @@ def help():
 
 # check here if covo is called as "python* covo" and define an offset for args
 arg_offset = 0
-if (sys.argv[0] != 'covo'): # if it is not covo, it must be initilized with some kind of python call
+if (os.path.basename(sys.argv[0]) != 'covo'): # if it is not covo, it must be initilized with some kind of python call
 	arg_offset = 1
 
 if len(sys.argv) == 1 + arg_offset:


### PR DESCRIPTION
Since #42, `covo` does not work anymore in my Anaconda environment (others may be affected):

```
$ echo hola | covo norm es
Mode es not found. Maybe try: covo help
```

The problem is that in some environments `sys.argv[0]` is something like `/home/xzuazo/anaconda3/envs/stt/bin/covo` in GNU/Linux.

This fixes the problem.

In the long-term, it might be better to change `covo` to use [`argparse`](https://docs.python.org/3/library/argparse.html) or a similar library.