### PR TITLE
Parallelize segment command using Python multiprocessing

### DIFF
--- a/covo
+++ b/covo
@@ -8,6 +8,8 @@ import urllib.request
 import json, os
 import ssl
 
+import multiprocessing as mp
+
 from cvutils import CV 
 from cvutils import Corpora 
 from cvutils import Segmenter
@@ -87,12 +89,11 @@ elif mode == 'tokenise':
 elif mode == 'segment':
 	locale = sys.argv[2 + arg_offset]
 	s = Segmenter(locale)
-	line = sys.stdin.readline()
-	while line:
-		for sentence in s.segment(line):
-			print(sentence)	
-		
-		line = sys.stdin.readline()
+	num_cpus = mp.cpu_count()
+	with mp.Pool(num_cpus) as pool:
+		for line in pool.imap(s.segment, sys.stdin):
+			for sentence in line:
+				print(sentence)
 
 elif mode == 'validate' or mode == 'norm' or mode == 'valid':
 	locale = sys.argv[2 + arg_offset]


### PR DESCRIPTION
This makes the `segment` command faster by using all the CPUs.

### Some Benchmarks

Segmenting a 100MB corpus using the original code in a computer with 32 CPUs:

```
$ time ( ./covo dump euwiki-latest-pages-articles.xml.bz2 | head -c 100M | ./covo segment eu &> /dev/null )
File detected as being bzip2.
( ./covo dump euwiki-latest-pages-articles.xml.bz2 | head -)  189,05s user 1,07s system 142% cpu 2:13,58 total
```

Using [`Pool.imap`](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.pool.Pool.imap):

```
$ time ( ./covo dump euwiki-latest-pages-articles.xml.bz2 | head -c 100M | ./covo-imap segment eu &> /dev/null )
File detected as being bzip2.
( ./covo dump euwiki-latest-pages-articles.xml.bz2 | head -)  356,11s user 11,13s system 732% cpu 50,159 total
```

Using [`Pool.imap_unordered`](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.pool.Pool.imap_unordered):

```
$ time ( ./covo dump euwiki-latest-pages-articles.xml.bz2 | head -c 100M | ./covo-imap_unordered segment eu &> /dev/null )
File detected as being bzip2.
( ./covo dump euwiki-latest-pages-articles.xml.bz2 | head -)  349,57s user 13,20s system 727% cpu 49,846 total
```

Summarizing:

| Method | Corpus | Command | Time |
| ----------- | ----------- | ----------------| ------- |
| Original | 100M    | `segment` |  2:13,58 |
| [`Pool.imap`](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.pool.Pool.imap) | 100M | `segment` | 0:50,16 |
| [`Pool.imap_unordered`](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.pool.Pool.imap_unordered) | 100M | `segment` | 0:49,85 |

In the PR here, I am using `Pool.imap` to conserve the order of the input, and because the unordered method doesn't seem to offer much improvement. I also tried parallelizing the `norm` and `text` commands, but those did not improve the overall speed: the main bottleneck seems to be in the segmenter.
