### PR TITLE
[PR] Fix portability issues caused by path calculations

### DIFF
--- a/covo
+++ b/covo
@@ -1,20 +1,20 @@
 #!/usr/bin/env python3
+"""covo cli"""
 
+
+import os
 import sys
-
-from pathlib import Path
-import urllib.request
-
-import json, os
-import ssl
-
+import json
+# import ssl
 import multiprocessing as mp
+import urllib.request
+# from pathlib import Path
 
-from cvutils import CV 
-from cvutils import Corpora 
+from cvutils import CV
+from cvutils import Corpora
 from cvutils import Segmenter
 from cvutils import Validator
-from cvutils import Alphabet 
+from cvutils import Alphabet
 from cvutils import Phonemiser
 from cvutils import Tokeniser
 
@@ -215,7 +215,7 @@ elif mode == 'clean':
 	valid_sents = 0
 	discarded = []
 	malformed = []
-	with open(sys.argv[3 + arg_offset]) as csv_file:
+	with open(sys.argv[3 + arg_offset], encoding="utf8") as csv_file:
 		csv_reader = csv.reader(csv_file, delimiter=',')
 		csv_writer = csv.writer(sys.stdout, delimiter=',')
 		csv_writer.writerow(next(csv_reader))
@@ -317,14 +317,14 @@ elif mode == 'avail':
 elif mode == 'gutenberg' or mode == 'guten' or mode == 'gb':
 	cmd = sys.argv[2 + arg_offset]
 	HOME = os.getenv('HOME')
-	covo_cache_dir = HOME + "/.covo/"
+	covo_cache_dir = os.path.join(HOME, ".covo")
 
 	from cvutils import gutenberg
 
 	def gb_update(covo_cache_dir):
 		if not os.path.isdir(covo_cache_dir):
 			os.mkdir(covo_cache_dir, mode=0o755)
-		fd = open(covo_cache_dir + "GUTINDEX.ALL", 'w')
+		fd = open(os.path.join(covo_cache_dir, "GUTINDEX.ALL"), 'w')
 		g = urllib.request.urlopen('https://www.gutenberg.org/dirs/GUTINDEX.ALL')
 		txt = g.read().strip()
 		fd.write(txt.decode('utf-8'))
@@ -388,7 +388,7 @@ elif mode == 'export':
 	tipus = sys.argv[2 + arg_offset]
 	locale = sys.argv[3 + arg_offset]
 	input_dir = sys.argv[4 + arg_offset]
-	output_dir = sys.argv[4 + arg_offset] + '/clips/'
+	output_dir = os.path.join(sys.argv[4 + arg_offset], 'clips')
 	if len(sys.argv) == 6 + arg_offset:
 		output_dir = sys.argv[5 + arg_offset]
 

--- a/cvutils/__init__.py
+++ b/cvutils/__init__.py
@@ -1,56 +1,66 @@
-import sys, os, pathlib, re
+"""commonvoice-utils main module"""
+import sys
+import os
+import pathlib
 
-sys.path.append(os.path.dirname(__file__))
-
-from phonemiser import Phonemiser
-from segmenter import Segmenter
-from validator import Validator
-from alphabet import Alphabet
-from corpora import Corpora
-from transliterator import Transliterator
-from tokeniser import Tokeniser
-from tagger import Tagger
-from gutenberg import Gutenberg
+from .phonemiser import Phonemiser
+from .segmenter import Segmenter
+from .validator import Validator
+from .alphabet import Alphabet
+from .corpora import Corpora
+from .transliterator import Transliterator
+from .tokeniser import Tokeniser
+from .tagger import Tagger
+from .gutenberg import Gutenberg
 
 # This is horrible, rewrite this
+sys.path.append(os.path.dirname(__file__))
 
 class CV:
-	def __init__(self):
-		self.supported = {'phonemiser':[], 'segmenter':[], 'validator':[], 'alphabet':[]}
+    """Class to access supported functionality for locales"""
+    def __init__(self):
+        self.supported = {
+            "phonemiser": [],
+            "segmenter": [],
+            "validator": [],
+            "alphabet": [],
+        }
 
-		data_dir = os.path.dirname(__file__) + '/data/'
-		for path in pathlib.Path(data_dir).rglob('alphabet.txt'):
-			locale = path.resolve()
-			locale = str(locale).replace('/alphabet.txt', '').split('/')[-1]
-			self.supported['alphabet'].append(locale)
+        data_dir = os.path.join(os.path.dirname(__file__), "data")
+        for path in pathlib.Path(data_dir).rglob("alphabet.txt"):
+            locale = str(path.resolve())
+            locale = os.path.split(os.path.split(locale)[0])[-1]
+            self.supported["alphabet"].append(locale)
 
-		for path in pathlib.Path(data_dir).rglob('validate.tsv'):
-			locale = path.resolve()
-			locale = str(locale).replace('/validate.tsv', '').split('/')[-1]
-			self.supported['validator'].append(locale)
+        for path in pathlib.Path(data_dir).rglob("validate.tsv"):
+            locale = str(path.resolve())
+            locale = os.path.split(os.path.split(locale)[0])[-1]
+            self.supported["validator"].append(locale)
 
-		for path in pathlib.Path(data_dir).rglob('phon.*'):
-			locale = path.resolve()
-			if '.att' not in str(locale) and '.tsv' not in str(locale):
-				continue
-			locale = re.sub('/phon.(att|tsv)', '', str(locale)).split('/')[-1]
-			self.supported['phonemiser'].append(locale)
-	
-		for path in pathlib.Path(data_dir).rglob('punct.tsv'):
-			locale = path.resolve()
-			locale = str(locale).replace('/punct.tsv', '').split('/')[-1]
-			self.supported['segmenter'].append(locale)
-							
-				
-	def alphabets(self):
-		return self.supported['alphabet']
+        for path in pathlib.Path(data_dir).rglob("phon.*"):
+            locale = str(path.resolve())
+            if ".att" not in locale and ".tsv" not in locale:
+                continue
+            locale = os.path.split(os.path.split(locale)[0])[-1]
+            self.supported["phonemiser"].append(locale)
 
-	def validators(self):
-		return self.supported['validator']
+        for path in pathlib.Path(data_dir).rglob("punct.tsv"):
+            locale = str(path.resolve())
+            locale = os.path.split(os.path.split(locale)[0])[-1]
+            self.supported["segmenter"].append(locale)
 
-	def phonemisers(self):
-		return self.supported['phonemiser']
+    def alphabets(self):
+        """Returns a list of all language codes supporting the Alphabet fuctionality"""
+        return self.supported["alphabet"]
 
-	def segmenters(self):
-		return self.supported['segmenter']
+    def validators(self):
+        """Returns a list of all language codes supporting the Validator fuctionality"""
+        return self.supported["validator"]
 
+    def phonemisers(self):
+        """Returns a list of all language codes supporting the Phonemizer fuctionality"""
+        return self.supported["phonemiser"]
+
+    def segmenters(self):
+        """Returns a list of all language codes supporting the Segmenter fuctionality"""
+        return self.supported["segmenter"]

--- a/cvutils/alphabet.py
+++ b/cvutils/alphabet.py
@@ -1,3 +1,4 @@
+"""Alphabet module"""
 import sys
 import os
 
@@ -16,8 +17,8 @@ class Alphabet:
 			print('[Alphabet] Function not implemented', file=sys.stderr)
 
 	def load_data(self):
-		data_dir = os.path.abspath(os.path.dirname(__file__)) + '/data/'
-		fd = open(data_dir + self.lang + '/alphabet.txt')
+		data_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'data')
+		fd = open(os.path.join(data_dir, self.lang, 'alphabet.txt'))
 		a = [' '] + [line.strip('\n') for line in fd.readlines()]
 		a = list(set(''.join(a)))
 		a.sort()

--- a/cvutils/corpora.py
+++ b/cvutils/corpora.py
@@ -1,4 +1,8 @@
-import os, urllib.request, re, sys
+"""Corpora module"""
+import os
+import sys
+import re
+import urllib.request
 
 class Corpora:
 	"""
@@ -26,17 +30,17 @@ class Corpora:
 		self.load_data()
 
 	def load_data(self):
-		data_dir = os.path.abspath(os.path.dirname(__file__)) + '/data/'
-		vocab_file = data_dir + self.lang + '/vocab.tsv'
+		data_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'data')
+		vocab_file = os.path.join(data_dir, self.lang, 'vocab.tsv')
 		self.small_vocab = []
 		if os.path.isfile(vocab_file):
-			fd = open(data_dir + self.lang + '/vocab.tsv')
+			fd = open(vocab_file)
 			self.small_vocab = [line.strip('\n') for line in fd.read().strip().split('\n')]
 		self.wikipedia_code = self.lang
-		wikipedia_file = data_dir + self.lang + '/wikipedia.txt'
+		wikipedia_file = os.path.join(data_dir, self.lang, 'wikipedia.txt')
 		if os.path.isfile(wikipedia_file):
 			self.wikipedia_code = open(wikipedia_file).read().strip()
-		for line in open(os.path.abspath(os.path.dirname(__file__))+'/opus.weights').readlines():
+		for line in open(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'opus.weights')).readlines():
 			(v, k, r) = line.strip().split('\t')
 			self.opus_weights[k] = (int(v), r.split(','))
 

--- a/cvutils/exporters/nemo.py
+++ b/cvutils/exporters/nemo.py
@@ -81,9 +81,9 @@ class NemoExporter:
 			tsv_file: str, path to *.csv file with data description, usually start from 'cv-'
 			data_root: str, path to dir to save results; wav/ dir will be created
 		"""
-		wav_dir = os.path.join(data_root, 'wav/')
+		wav_dir = os.path.join(data_root, 'wav')
 		os.makedirs(wav_dir, exist_ok=True)
-		audio_clips_path = os.path.dirname(tsv_file) + '/clips/'
+		audio_clips_path = os.path.join(os.path.dirname(tsv_file), 'clips')
 	
 		def process(x):
 			file_path, text = x

--- a/cvutils/phonemiser.py
+++ b/cvutils/phonemiser.py
@@ -1,7 +1,10 @@
-import re, os, sys
-from att import ATTFST
+"""Phonemiser module"""
+import os
+import sys
 import pathlib
-from validator import Validator
+
+from .att import ATTFST
+from .validator import Validator
 
 class Phonemiser:
 	"""
@@ -29,7 +32,7 @@ class Phonemiser:
 
 	def load_data(self):
 		self.lkp = {}
-		data_dir = os.path.abspath(os.path.dirname(__file__)) + '/data/' + self.lang + '/'
+		data_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'data', self.lang)
 		paths = [p.name for p in pathlib.Path(data_dir).glob('phon.*')]
 		if len(paths) == 0:
 			raise FileNotFoundError
@@ -42,13 +45,13 @@ class Phonemiser:
 				break
 
 	def load_data_att(self):
-		data_dir = os.path.abspath(os.path.dirname(__file__)) + '/data/' + self.lang + '/'
-		self.transducer = ATTFST(data_dir + '/phon.att')	
+		data_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'data', self.lang)
+		self.transducer = ATTFST(os.path.join(data_dir, 'phon.att'))
 		self.phonemise = self.lookup_att
 
 	def load_data_tsv(self):
-		data_dir = os.path.abspath(os.path.dirname(__file__)) + '/data/' + self.lang + '/'
-		fd = open(data_dir + '/phon.tsv')
+		data_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'data', self.lang)
+		fd = open(os.path.join(data_dir, 'phon.tsv'))
 		line = fd.readline() # Skip the first line
 		line = fd.readline()
 		while line:

--- a/cvutils/segmenter.py
+++ b/cvutils/segmenter.py
@@ -1,4 +1,7 @@
-import re, os, sys
+"""Segmenter module"""
+import os
+import sys
+import re
 
 class Segmenter:
 	"""
@@ -18,19 +21,19 @@ class Segmenter:
 
 	def load_data(self):
 		self.eos = []
-		data_dir = os.path.abspath(os.path.dirname(__file__)) + '/data/'
-		for line in open(data_dir + self.lang + '/validate.tsv').readlines():
+		data_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'data')
+		for line in open(os.path.join(data_dir, self.lang, 'validate.tsv'), encoding="utf8").readlines():
 			row = line.strip('\n').split('\t')
 			if row[0] == 'NORM':
 				k = row[1].strip()	
 				v = row[2].strip()	
 				self.transform[k] = v
-		for line in open(data_dir + self.lang + '/punct.tsv').readlines():
+		for line in open(os.path.join(data_dir, self.lang, 'punct.tsv'), encoding="utf8").readlines():
 			row = line.strip('\n').split('\t')
 			k = row[1].strip()	
 			self.eos.append(k)
 		self.abbr = []
-		for line in open(data_dir + self.lang + '/abbr.tsv').readlines():
+		for line in open(os.path.join(data_dir, self.lang, 'abbr.tsv'), encoding="utf8" ).readlines():
 			row = line.strip('\n').split('\t')
 			k = row[1].strip()	
 			self.abbr.append(k.replace('.', '\\.'))

--- a/cvutils/transliterator.py
+++ b/cvutils/transliterator.py
@@ -1,7 +1,12 @@
-import re, os, sys
-from att import ATTFST
+"""Transliterator module"""
+import os
+import sys
+import re
 import pathlib
-from validator import Validator
+
+from .validator import Validator
+# from .att import ATTFST
+
 
 class Transliterator:
 	"""
@@ -16,6 +21,7 @@ class Transliterator:
 		self.detector = {}
 		self.transducer = None
 		self.normalise = None
+		self.transliterate = None
 		try:
 			self.load_data()
 		except FileNotFoundError:
@@ -29,7 +35,7 @@ class Transliterator:
 
 	def load_data(self):
 		self.lkp = {}
-		data_dir = os.path.abspath(os.path.dirname(__file__)) + '/data/' + self.lang + '/'
+		data_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'data', self.lang)
 		paths = [p.name for p in pathlib.Path(data_dir).glob('transliterate.*')]
 		if len(paths) == 0:
 			raise FileNotFoundError
@@ -47,8 +53,8 @@ class Transliterator:
 	#	self.transliterate = self.lookup_att
 
 	def load_data_tsv(self):
-		data_dir = os.path.abspath(os.path.dirname(__file__)) + '/data/' + self.lang + '/'
-		fd = open(data_dir + '/transliterate.tsv')
+		data_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'data', self.lang)
+		fd = open(os.path.join(data_dir,'transliterate.tsv'))
 		# Cyrl	Latn
 		scripts_row = fd.readline().strip().split('\t') 
 		# [а-я]	[a-z]

--- a/cvutils/validator.py
+++ b/cvutils/validator.py
@@ -1,4 +1,8 @@
-import re, os, sys, unicodedata
+"""Validator module"""
+import os
+import sys
+import re
+import unicodedata
 
 class Validator:
 	"""
@@ -22,8 +26,8 @@ class Validator:
 		self.skip = [] 
 		self.transform = {}
 		self.lower = False
-		data_dir = os.path.abspath(os.path.dirname(__file__)) + '/data/'
-		for line in open(data_dir + self.lang + '/validate.tsv').readlines():
+		data_dir = os.path.join(os.path.abspath(os.path.dirname(__file__)), 'data')
+		for line in open(os.path.join(data_dir, self.lang, 'validate.tsv'), encoding="utf8").readlines():
 			if line[0] == '#':
 				continue
 			row = line.strip('\n').split('\t')
@@ -54,8 +58,8 @@ class Validator:
 			self.transform['\u00ad'] = ''
 		#print('T:', self.transform, file=sys.stderr)
 
-	def set_alphabet(s):
-		self.alphabet = s
+	# def set_alphabet(s):
+	# 	self.alphabet = s
 
 	def validate(self, transcript):
 		"""Returns either the normalised transcript or None"""


### PR DESCRIPTION
Note: This is not tested extensively.

- Replace path calculations using os.path.join
- Some PyLint suggested fixes (re. PEPs)

These were the cause of my problems I encountered on Windows, see #37 that we closed.

There are other portability issues which I did not handle here, such as:
- Using sox
- Using "/dev/stdxxx"

I also suggest using the Black Formatter, PyLint fixes and using modern typing/dataclasses for the whole repo, which I can handle if you like.

